### PR TITLE
chore/슬랙 알림 테스트

### DIFF
--- a/.github/userlist.toml
+++ b/.github/userlist.toml
@@ -1,0 +1,7 @@
+[[users]]
+github = "obb8923"
+slack = "U08BKC9SP1A"
+
+[[users]]
+github = "salmonco"
+slack = "U08B2FMRY15"

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,19 @@
+name: GitHub Notification
+
+on:
+  pull_request:
+    types: [review_requested, closed]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+  pull_request_review_comment:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ken-matsui/notify-slack@v1.0.4
+        with:
+          slack_oauth_access_token: ${{ secrets.SLACK_OAUTH_ACCESS_TOKEN }}


### PR DESCRIPTION
## 작업 분류

- [ ] 기능 추가
- [ ] QA 반영
- [ ] 리팩토링
- [x] 기타

## 요구사항

- 유저가 멘션되었을 때 슬랙에 알림 오는지 테스트

## 작업 내용

- 사용한 깃헙액션: https://github.com/marketplace/actions/notify-works-on-github-to-slack
  - [슬랙 API 사이트](https://api.slack.com/)에서 Slack Bot User OAuth Token 생성해서 깃헙 파일에 넣어주고
  - 깃헙 아이디랑 슬랙 멤버 아이디를 유저마다 매칭해서 일일이 깃헙 파일에 넣어줘야 함
- close #101

## 테스트

<!-- 시연영상, 복잡한 로직의 경우 테스트 코드 등 -->
