### PR TITLE
feat/회원탈퇴 하단 버튼 플로팅

### DIFF
--- a/src/components/DismissKeyboardView/index.tsx
+++ b/src/components/DismissKeyboardView/index.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import {
   Keyboard,
   type StyleProp,
@@ -8,7 +9,7 @@ import {
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 type Component = {
-  children: JSX.Element[] | JSX.Element;
+  children: ReactNode;
   footer?: JSX.Element;
   style?: StyleProp<ViewStyle>;
 };

--- a/src/screens/System/MyAccount/LeaveAccount/LeaveAccount2/index.tsx
+++ b/src/screens/System/MyAccount/LeaveAccount/LeaveAccount2/index.tsx
@@ -14,8 +14,11 @@ import { Button } from '@components/Button';
 import { CustomText } from '@components/CustomText';
 import { FlexableMargin } from '@components/FlexableMargin';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useNavigation } from '@react-navigation/native';
-import { type NavigationProp, type RouteProp } from '@react-navigation/native';
+import {
+  type NavigationProp,
+  type RouteProp,
+  useNavigation,
+} from '@react-navigation/native';
 import { type SystemStackParamList } from '@type/nav/SystemStackParamList';
 // utils
 import { redirectToAuthScreen } from '@utils/redirectToAuthScreen';
@@ -111,7 +114,7 @@ export const LeaveAccount2Screen = ({
           navigation.goBack();
         }}
       />
-      <View className="px-px" style={{ height: windowHeight - 64 }}>
+      <View className="px-px" style={{ height: windowHeight - 196 }}>
         {/* 상단 영역 */}
         {role == 'HELPER' ? (
           <>
@@ -124,7 +127,7 @@ export const LeaveAccount2Screen = ({
             />
             <FlexableMargin flexGrow={21} />
             <View className="w-full flex-row">
-              <CustomText type="title4" text="정말" className="text-white" />
+              <CustomText type="title4" text="정말 " className="text-white" />
               <CustomText
                 type="title4"
                 text="내일모래"
@@ -224,37 +227,37 @@ export const LeaveAccount2Screen = ({
             <FlexableMargin flexGrow={479} />
           </>
         )}
+        <FlexableMargin flexGrow={196} />
+      </View>
 
-        {/* 버튼 영역 */}
-        <View className="w-full ">
-          {/* 회원 탈퇴 확인완료 버튼 */}
+      {/* 버튼 영역 */}
+      <View className={`absolute left-0 bottom-[55] w-full px-[30]`}>
+        {/* 회원 탈퇴 확인완료 버튼 */}
+        <View
+          className="flex-row items-center justify-center py-[18] space-x-[10px]"
+          onTouchEnd={() => setIsConfirmed(!isConfirmed)}>
+          {/* 체크박스 원 */}
           <View
-            className="flex-row items-center justify-center py-[18] space-x-[10px]"
-            onTouchEnd={() => setIsConfirmed(!isConfirmed)}>
-            {/* 체크박스 원 */}
-            <View
-              className={`w-[20px] h-[20px] rounded-full ${
-                isConfirmed ? 'bg-yellowPrimary' : 'bg-blue600'
-              } justify-center items-center`}>
-              {isConfirmed && (
-                <View className="w-[6px] h-[10px] border-r-2 border-b-2 border-blue700 rotate-45" />
-              )}
-            </View>
-            {/* 텍스트 */}
-            <CustomText
-              type="body4"
-              text="회원 탈퇴 유의사항을 확인했습니다"
-              className="text-gray200"
-            />
+            className={`w-[20px] h-[20px] rounded-full ${
+              isConfirmed ? 'bg-yellowPrimary' : 'bg-blue600'
+            } justify-center items-center`}>
+            {isConfirmed && (
+              <View className="w-[6px] h-[10px] border-r-2 border-b-2 border-blue700 rotate-45" />
+            )}
           </View>
-          {/* 회원 탈퇴 버튼 */}
-          <Button
-            text="회원 탈퇴하고 계정 삭제하기"
-            onPress={handleDeleteMember}
-            disabled={!isConfirmed}
+          {/* 텍스트 */}
+          <CustomText
+            type="body4"
+            text="회원 탈퇴 유의사항을 확인했습니다"
+            className="text-gray200"
           />
         </View>
-        <FlexableMargin flexGrow={55} />
+        {/* 회원 탈퇴 버튼 */}
+        <Button
+          text="회원 탈퇴하고 계정 삭제하기"
+          onPress={handleDeleteMember}
+          disabled={!isConfirmed}
+        />
       </View>
     </BG>
   );

--- a/src/screens/System/MyAccount/LeaveAccount/index.tsx
+++ b/src/screens/System/MyAccount/LeaveAccount/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pressable, ScrollView, View } from 'react-native';
+import { Platform, Pressable, ScrollView, View } from 'react-native';
 
 import { AppBar } from '@components/AppBar';
 import { BG } from '@components/BG';
@@ -36,20 +36,30 @@ export const LeaveAccountScreen = () => {
     <BG type="solid">
       <DismissKeyboardView
         footer={
-          <View className={`absolute left-0 bottom-[55] w-full px-[30]`}>
-            <Button
-              text="다음"
-              onPress={() => {
-                navigation.navigate('LeaveAccount2', {
-                  reasons: selectedReasons,
-                  otherReason: selectedReasons.includes('기타')
-                    ? detailReason
-                    : '',
-                });
-              }}
-              disabled={selectedReasons.length === 0}
+          <>
+            <View
+              className={`absolute left-0 bottom-0 w-full bg-blue700 ${
+                Platform.OS === 'ios' ? 'h-[163]' : 'h-[139]'
+              }`}
             />
-          </View>
+            <View
+              className={`absolute left-0 w-full px-[30] ${
+                Platform.OS === 'ios' ? 'bottom-[79]' : 'bottom-[55]'
+              }`}>
+              <Button
+                text="다음"
+                onPress={() => {
+                  navigation.navigate('LeaveAccount2', {
+                    reasons: selectedReasons,
+                    otherReason: selectedReasons.includes('기타')
+                      ? detailReason
+                      : '',
+                  });
+                }}
+                disabled={selectedReasons.length === 0}
+              />
+            </View>
+          </>
         }>
         <AppBar
           title="회원 탈퇴"
@@ -57,7 +67,7 @@ export const LeaveAccountScreen = () => {
         />
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           {/* 전체 컨테이너 */}
-          <View className="flex-1 items-center pb-[150]">
+          <View className="flex-1 items-center pb-[174]">
             {/* 안내 문구 */}
             <View className="py-[41] px-px gap-[3] w-full">
               <CustomText
@@ -155,7 +165,7 @@ const ReasonItem = ({
   return (
     <Pressable
       onPress={onPress}
-      className="flex-row gap-[21] items-center w-full px-px py-[32]">
+      className="flex-row gap-[21] items-center w-full px-px py-[24]">
       <View
         className={`w-[20px] h-[20px] ${
           isSelected ? 'bg-yellowPrimary' : 'bg-blue500'

--- a/src/screens/System/MyAccount/LeaveAccount/index.tsx
+++ b/src/screens/System/MyAccount/LeaveAccount/index.tsx
@@ -1,19 +1,13 @@
 import { useState } from 'react';
-import {
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  ScrollView,
-  View,
-} from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 import { AppBar } from '@components/AppBar';
 import { BG } from '@components/BG';
 import { Button } from '@components/Button';
 import { CustomText } from '@components/CustomText';
+import { DismissKeyboardView } from '@components/DismissKeyboardView';
 import { TextInput } from '@components/TextInput';
-import { useNavigation } from '@react-navigation/native';
-import { type NavigationProp } from '@react-navigation/native';
+import { type NavigationProp, useNavigation } from '@react-navigation/native';
 import { type SystemStackParamList } from '@type/nav/SystemStackParamList';
 
 const LeaveReasons = [
@@ -39,17 +33,31 @@ export const LeaveAccountScreen = () => {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-      <BG type="solid">
+    <BG type="solid">
+      <DismissKeyboardView
+        footer={
+          <View className={`absolute left-0 bottom-[55] w-full px-[30]`}>
+            <Button
+              text="다음"
+              onPress={() => {
+                navigation.navigate('LeaveAccount2', {
+                  reasons: selectedReasons,
+                  otherReason: selectedReasons.includes('기타')
+                    ? detailReason
+                    : '',
+                });
+              }}
+              disabled={selectedReasons.length === 0}
+            />
+          </View>
+        }>
         <AppBar
           title="회원 탈퇴"
           goBackCallbackFn={() => navigation.goBack()}
         />
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           {/* 전체 컨테이너 */}
-          <View className="flex-1 items-center">
+          <View className="flex-1 items-center pb-[150]">
             {/* 안내 문구 */}
             <View className="py-[41] px-px gap-[3] w-full">
               <CustomText
@@ -74,70 +82,52 @@ export const LeaveAccountScreen = () => {
                 onPress={() => toggleReason(reason)}
               />
             ))}
-            <>
-              <ReasonItem
-                reason="기타"
-                isSelected={selectedReasons.includes('기타')}
-                onPress={() => {
-                  toggleReason('기타');
+            <ReasonItem
+              reason="기타"
+              isSelected={selectedReasons.includes('기타')}
+              onPress={() => {
+                toggleReason('기타');
+                setIsDetailTyping(true);
+              }}
+            />
+            {selectedReasons.includes('기타') && (
+              <View
+                className="w-full px-px"
+                onTouchStart={() => {
                   setIsDetailTyping(true);
-                }}
-              />
-              {selectedReasons.includes('기타') && (
-                <View
-                  className="w-full px-px"
-                  onTouchStart={() => {
-                    setIsDetailTyping(true);
-                  }}>
-                  <TextInput
-                    autoFocus
-                    value={detailReason}
-                    onChangeText={setDetailReason}
-                    placeholder="내용을 입력해주세요"
-                    isError={false}
-                    maxLength={160}
-                  />
-                </View>
-              )}
-            </>
-            <View className="w-full px-px mt-[29] mb-[55]">
-              <Button
-                text="다음"
-                onPress={() => {
-                  navigation.navigate('LeaveAccount2', {
-                    reasons: selectedReasons,
-                    otherReason: selectedReasons.includes('기타')
-                      ? detailReason
-                      : '',
-                  });
-                }}
-                disabled={selectedReasons.length === 0}
-              />
-            </View>
+                }}>
+                <TextInput
+                  autoFocus
+                  value={detailReason}
+                  onChangeText={setDetailReason}
+                  placeholder="내용을 입력해주세요"
+                  isError={false}
+                  maxLength={160}
+                />
+              </View>
+            )}
           </View>
         </ScrollView>
         {isDetailTyping && (
           <View className="absolute top-0 right-0 h-full w-full z-[9]">
             <BG type="solid">
-              <View className="mt-[64]">
-                <ReasonItem
-                  reason="기타"
-                  isSelected={selectedReasons.includes('기타')}
-                  onPress={() => {
-                    toggleReason('기타');
-                    setIsDetailTyping(false);
-                  }}
+              <ReasonItem
+                reason="기타"
+                isSelected={selectedReasons.includes('기타')}
+                onPress={() => {
+                  toggleReason('기타');
+                  setIsDetailTyping(false);
+                }}
+              />
+              <View className="w-full px-px">
+                <TextInput
+                  autoFocus
+                  value={detailReason}
+                  onChangeText={setDetailReason}
+                  placeholder="내용을 입력해주세요"
+                  isError={false}
+                  maxLength={160}
                 />
-                <View className="w-full px-px">
-                  <TextInput
-                    autoFocus
-                    value={detailReason}
-                    onChangeText={setDetailReason}
-                    placeholder="내용을 입력해주세요"
-                    isError={false}
-                    maxLength={160}
-                  />
-                </View>
               </View>
               <View
                 className="flex-1"
@@ -148,8 +138,8 @@ export const LeaveAccountScreen = () => {
             </BG>
           </View>
         )}
-      </BG>
-    </KeyboardAvoidingView>
+      </DismissKeyboardView>
+    </BG>
   );
 };
 


### PR DESCRIPTION
## 작업 분류

- [x] 기능 추가
- [ ] QA 반영
- [ ] 리팩토링

## 요구사항

- 공통 > 설정 > 내 계정 > 회원 탈퇴 > 밑에 버튼 플로팅되도록 해야 함

## 작업 내용

- close #111 

## 테스트

<!-- 시연영상, 복잡한 로직의 경우 테스트 코드 등 -->

### 탈퇴 이유 선택 화면

| AS-IS | TO-BE |
|---|---|
| <img width="300" alt="" src="https://github.com/user-attachments/assets/63c3880b-9e65-40bd-bb1a-5ab787fb2a44" /> | <img width="300" alt="" src="https://github.com/user-attachments/assets/ea31b76d-b757-4e10-b20c-47d4bf6851a6" /> |

### 탈퇴하기 화면

| AS-IS | TO-BE |
|---|---|
| <img width="300" alt="" src="https://github.com/user-attachments/assets/f69ab1ea-390a-42f9-bdd4-56144b4d581b" /> | <img width="300" alt="" src="https://github.com/user-attachments/assets/f7150d31-1fdd-4115-8e4c-59ed1ad6c7be" /> |