### PR TITLE
[ios] feat/fcm 푸시알림 설정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -91,9 +91,34 @@ export function App(): React.JSX.Element {
     (async () => {
       const role = (await AsyncStorage.getItem('role')) as Role;
 
-      // TODO: forground 상태에서 똑같은 푸시알림이 연속 두 번 오는 문제 (only ios)
+      let lastMessageId: string | null = null;
+
       const unsubscribe = messaging().onMessage(async remoteMessage => {
         console.log('Foreground Push in App', remoteMessage);
+
+        /**
+         * TODO: forground 상태에서 똑같은 푸시알림이 연속 두 번 오는 문제 (only ios)
+         *
+         * 해결방안 1. 프론트에서 messageId 를 비교해서 중복 알림인 경우 무시한다. -> 현재 이걸로 적용
+         * 해결방안 2. 서버에서 data-only 알림을 보내준다.
+         * 지금은 알림 데이터가 아래처럼 data 필드 이외에 notification 필드가 함께 오고 있다.
+         * {
+         *  messageId: '1745148372238320',
+         *  data: { alarmId: '1' },
+         *  notification: { title: 'testtest' },
+         *  from: '427805097209'
+         * }
+         */
+        if (remoteMessage?.messageId === lastMessageId) {
+          console.log(
+            '[foreground] duplicate notification:',
+            remoteMessage.messageId,
+          );
+
+          return;
+        }
+
+        lastMessageId = remoteMessage.messageId ?? null;
 
         const { alarmId } = remoteMessage.data as RemoteMessageData;
 

--- a/App.tsx
+++ b/App.tsx
@@ -91,6 +91,7 @@ export function App(): React.JSX.Element {
     (async () => {
       const role = (await AsyncStorage.getItem('role')) as Role;
 
+      // TODO: forground 상태에서 똑같은 푸시알림이 연속 두 번 오는 문제 (only ios)
       const unsubscribe = messaging().onMessage(async remoteMessage => {
         console.log('Foreground Push in App', remoteMessage);
 

--- a/ios/naeilmorae/AppDelegate.mm
+++ b/ios/naeilmorae/AppDelegate.mm
@@ -1,3 +1,4 @@
+#import <Firebase.h>
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
@@ -7,7 +8,9 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  [FIRApp configure];
+  if ([FIRApp defaultApp] == nil) {
+    [FIRApp configure];
+  }
   self.moduleName = @"naeilmorae";
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.

--- a/ios/naeilmorae/Info.plist
+++ b/ios/naeilmorae/Info.plist
@@ -27,7 +27,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-			<string>kakaof75a34680c8df270b1e012834770bae4</string>
+				<string>kakaof75a34680c8df270b1e012834770bae4</string>
 			</array>
 		</dict>
 	</array>
@@ -44,16 +44,16 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>내일모래에서 위치별 날씨 알림을 제공하기 위해 사용됩니다. 해당 정보는 내일모래 서버에 저장되며 서비스 외 용도로 사용되지 않습니다.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>내일모래에서 위치별 날씨 알림을 제공하기 위해 사용됩니다. 해당 정보는 내일모래 서버에 저장되며 서비스 외 용도로 사용되지 않습니다.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-  	<string>내일모래에서 위치별 날씨 알림을 제공하기 위해 사용됩니다. 해당 정보는 내일모래 서버에 저장되며 서비스 외 용도로 사용되지 않습니다.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>내일모래에서 프로필 작성 용도로 사용됩니다.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>내일모래에서 목소리 알림 녹음의 용도로 사용됩니다.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>내일모래에서 프로필 작성 용도로 사용됩니다.</string>
-	<key>NSMicrophoneUsageDescription</key>
-  	<string>내일모래에서 목소리 알림 녹음의 용도로 사용됩니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>내일모래에서 프로필 작성 용도로 사용됩니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>WantedSans-Medium.otf</string>
@@ -62,6 +62,10 @@
 		<string>LeeSeoyun-Regular.ttf</string>
 		<string>Voltaire-Regular.ttf</string>
 		<string>AppleSDGothicNeoR.ttf</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/src/libs/utils/pushNoti.ts
+++ b/src/libs/utils/pushNoti.ts
@@ -5,12 +5,17 @@
  * 이 모듈은 앱 내 푸시 알림 표시, 알림 클릭 이벤트 처리 등의 기능을 제공합니다.
  */
 
+import { Platform } from 'react-native';
+
 import notifee, { AndroidImportance, EventType } from '@notifee/react-native';
 import { navigateToVolunteerHomeScreen } from '@utils/navigateToVolunteerHomeScreen';
 import { navigateToYouthListenScreen } from '@utils/navigateToYouthListenScreen';
 import { trackEvent } from '@utils/tracker';
 
 export type RemoteMessageData = { alarmId: string };
+
+const ID = 'default';
+const NAME = '내일모래';
 
 /**
  * 푸시 알림을 화면에 표시하는 함수
@@ -30,24 +35,45 @@ const displayNotification = async ({
   body,
   data,
 }: Readonly<{ title: string; body: string; data: { alarmId?: number } }>) => {
-  const channelAnoucement = await notifee.createChannel({
-    id: 'default',
-    name: '내일모래',
-    importance: AndroidImportance.HIGH,
-  });
+  if (Platform.OS === 'android') {
+    const channelAnoucement = await notifee.createChannel({
+      id: ID,
+      name: NAME,
+      importance: AndroidImportance.HIGH,
+      sound: 'sound',
+    });
 
-  await notifee.displayNotification({
-    title,
-    body,
-    android: {
-      channelId: channelAnoucement,
-      // smallIcon: 'ic_launcher',
-      largeIcon: 'ic_launcher',
-      circularLargeIcon: true,
-      color: '#555555',
-    },
-    data,
-  });
+    await notifee.displayNotification({
+      id: ID,
+      title,
+      body,
+      android: {
+        channelId: channelAnoucement,
+        // smallIcon: 'ic_launcher',
+        largeIcon: 'ic_launcher',
+        circularLargeIcon: true,
+        color: '#555555',
+        sound: 'sound',
+        timestamp: Date.now(),
+        showTimestamp: true,
+      },
+      data,
+    });
+
+    return;
+  }
+
+  if (Platform.OS === 'ios') {
+    notifee.displayNotification({
+      id: ID,
+      title,
+      body,
+      ios: {
+        sound: 'default',
+      },
+      data,
+    });
+  }
 };
 
 /**


### PR DESCRIPTION
## 작업 분류

- [x] 기능 추가
- [ ] QA 반영
- [ ] 리팩토링

## 요구사항

- [ios 대응] 공통 > fcm 알림 테스트

## 작업 내용

- close #147 

[참고한 포스팅](https://velog.io/@mayinjanuary/React-Native-Firebase-%EB%A1%9C-%ED%91%B8%EC%89%AC-%EC%95%8C%EB%A6%BC-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-2-IOS-%EC%95%B1-%EC%84%B8%ED%8C%85%ED%95%98%EA%B8%B0)

### ios 에서 foreground 알림이 두 번 중복해서 오는 문제

- fcm + notifee 중복해서 옴
- 아래처럼 last message id 비교해서 해결

```javascript
let lastMessageId: string | null = null;

messaging().onMessage(async remoteMessage => {
  if (remoteMessage?.messageId === lastMessageId) {
    console.log('[foreground] duplicate notification:', remoteMessage.messageId);
    return;
  }

  lastMessageId = remoteMessage.messageId ?? null;

  await notifee.displayNotification({
    // ...
  });
});
```

## 테스트

<!-- 시연영상, 복잡한 로직의 경우 테스트 코드 등 -->

- foreground, background, quit 상태에서 알림 오는 거 확인
- ios, 안드 둘 다 알림오는 동작 확인