### PR TITLE
feat/js bundle 참조 위치를 cdn 경로로 변경

### DIFF
--- a/android/app/src/main/java/com/jeong/naeilmorae/MainApplication.kt
+++ b/android/app/src/main/java/com/jeong/naeilmorae/MainApplication.kt
@@ -20,6 +20,17 @@ class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {
+        // Code Push via CDN
+        override fun getJSBundleFile(): String? {
+            return if (BuildConfig.DEBUG) {
+                // 디버그 모드일 때는 null 반환해서 Metro 서버 연결
+                null
+            } else {
+                // 릴리즈 모드일 때는 CDN 번들 사용
+                "https://ip-file-upload-test.s3.ap-northeast-2.amazonaws.com/naeilmorae-bundle/index.android.bundle"
+            }
+        }
+        
         override fun getPackages(): List<ReactPackage> =
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -11,7 +11,8 @@ end
 node_require('react-native/scripts/react_native_pods.rb')
 node_require('react-native-permissions/scripts/setup.rb')
 
-platform :ios, min_ios_version_supported
+# RNZipArchive 의 ios min version 은 15.5 이다. (react-native-zip-archive 깃헙 issue 참고)
+platform :ios, '15.5'
 prepare_react_native_project!
 
 # ⬇️ uncomment the permissions you need

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2187,7 +2187,15 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNZipArchive (7.0.1):
+    - React-Core
+    - RNZipArchive/Core (= 7.0.1)
+    - SSZipArchive (~> 2.5.5)
+  - RNZipArchive/Core (7.0.1):
+    - React-Core
+    - SSZipArchive (~> 2.5.5)
   - SocketRocket (0.7.1)
+  - SSZipArchive (2.5.5)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2284,6 +2292,7 @@ DEPENDENCIES:
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
+  - RNZipArchive (from `../node_modules/react-native-zip-archive`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -2306,6 +2315,7 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - SocketRocket
+    - SSZipArchive
 
 EXTERNAL SOURCES:
   amplitude-react-native:
@@ -2487,6 +2497,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
+  RNZipArchive:
+    :path: "../node_modules/react-native-zip-archive"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -2597,9 +2609,11 @@ SPEC CHECKSUMS:
   RNReanimated: a9ec0c4f97056a56c63d59d423f3bd18d539673c
   RNScreens: 2629b92a0f38e7432677bee3bc08a352ac5b4279
   RNSVG: 030717ff82ea8f2117347c2fcf52a2d1eafba9ba
+  RNZipArchive: f4a5af907d1581e995c879e34799be35c6bc3e21
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
+  SSZipArchive: c69881e8ac5521f0e622291387add5f60f30f3c4
   Yoga: 3deb2471faa9916c8a82dda2a22d3fba2620ad37
 
-PODFILE CHECKSUM: f91f218dea6ff286f7574b55a7adf1198cb7b470
+PODFILE CHECKSUM: fa33e3b6620e635df7f17f107277bae4783b0431
 
 COCOAPODS: 1.16.2

--- a/ios/naeilmorae/AppDelegate.mm
+++ b/ios/naeilmorae/AppDelegate.mm
@@ -40,7 +40,9 @@
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  // return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  // Code Push via CDN
+  return [NSURL URLWithString:@"https://ip-file-upload-test.s3.ap-northeast-2.amazonaws.com/naeilmorae-bundle/index.ios.bundle"];
 #endif
 }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint --ext .tsx --ext .ts src/"
+    "lint": "eslint --ext .tsx --ext .ts src/",
+    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/android/index.android.bundle --assets-dest dist/android",
+    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output dist/ios/index.ios.bundle --assets-dest dist/ios",
+    "bundle": "yarn bundle:android && yarn bundle:ios"
   },
   "dependencies": {
     "@amplitude/analytics-react-native": "^1.4.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,13 @@
     "lint": "eslint --ext .tsx --ext .ts src/",
     "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/android/index.android.bundle --assets-dest dist/android/assets",
     "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output dist/ios/index.ios.bundle --assets-dest dist/ios/assets",
-    "bundle": "yarn bundle:android && yarn bundle:ios"
+    "zip:android": "cd dist/android && zip -r ../bundle.android.zip .",
+    "zip:ios": "cd dist/ios && zip -r ../bundle.ios.zip .",
+    "upload:android": "aws s3 cp dist/bundle.android.zip s3://ip-file-upload-test/naeilmorae-bundle/bundle.android.zip",
+    "upload:ios": "aws s3 cp dist/bundle.ios.zip s3://ip-file-upload-test/naeilmorae-bundle/bundle.ios.zip",
+    "deploy:android": "yarn bundle:android && yarn zip:android && yarn upload:android",
+    "deploy:ios": "yarn bundle:ios && yarn zip:ios && yarn upload:ios",
+    "deploy": "yarn deploy:android && yarn deploy:ios"
   },
   "dependencies": {
     "@amplitude/analytics-react-native": "^1.4.11",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint --ext .tsx --ext .ts src/",
-    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/android/index.android.bundle --assets-dest dist/android",
-    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output dist/ios/index.ios.bundle --assets-dest dist/ios",
+    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/index.android.bundle",
+    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output dist/index.ios.bundle",
     "bundle": "yarn bundle:android && yarn bundle:ios"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint --ext .tsx --ext .ts src/",
-    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/index.android.bundle",
-    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output dist/index.ios.bundle",
+    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/android/index.android.bundle --assets-dest dist/android/assets",
+    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output dist/ios/index.ios.bundle --assets-dest dist/ios/assets",
     "bundle": "yarn bundle:android && yarn bundle:ios"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-native-screens": "^4.1.0",
     "react-native-splash-screen": "^3.3.0",
     "react-native-toast-message": "^2.2.1",
+    "react-native-zip-archive": "^7.0.1",
     "tailwindcss": "3.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8195,6 +8195,11 @@ react-native-toast-message@^2.2.1:
   resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.2.1.tgz#f395321e9bc818ce63274c38a3d294ed997a4a27"
   integrity sha512-iXFMnlxPcgKKs4bZOIl06W16m6KXMh/bAYpWLyVXlISSCdcL2+FX5WPpRP3TGQeM/u9q+j5ex48DDY+72en+Sw==
 
+react-native-zip-archive@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-7.0.1.tgz#d682a208de72da6d3609d7a3a60d65465dfc6f83"
+  integrity sha512-Zd3TDVCUQkAC3jjvmFjjJHOoig+ryYcOMrh7iLiwQCqe8TgrGJm3rhDNDgpfHKdLRMlIletvz2sh9OOttb0dZQ==
+
 react-native@*:
   version "0.78.0"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.78.0.tgz#3e76252c8f8f35e5b7e07f9d8aee775aa8a315a7"


### PR DESCRIPTION
## 작업 분류

- [x] 기능 추가
- [ ] QA 반영
- [ ] 리팩토링

## 요구사항

- code push 환경 구축

## 작업 내용

- close #165 

[트러블슈팅](https://github.com/salmonco/tip-archive/issues/50)

### TODO

- 이미지 등 정적 리소스도 CDN 에 올려서 참조하게 하기 -> require(...) 로 참조하던 것을 외부 url 바라보도록 경로 변경해야 함
- ios 배포 이후 진행

## 테스트

<!-- 시연영상, 복잡한 로직의 경우 테스트 코드 등 -->
